### PR TITLE
Remove long descriptions from template names

### DIFF
--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/blockbuster.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/blockbuster.JSON
@@ -1,5 +1,6 @@
 {
-	"Blockbuster (ban fly/DD, 2 player, 15-Jun-03, midnight design)" :
+	"Blockbuster" :
+	//(ban fly/DD, 2 player, 15-Jun-03, midnight design)
 	{
 		"minSize" : "m", "maxSize" : "m",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/extreme ii.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/extreme ii.JSON
@@ -1,5 +1,6 @@
 {
-	"EXTREME II (ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design)" :
+	"EXTREME II":
+	//(ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design)"
 	{
 		"minSize" : "l", "maxSize" : "l",
 		"players" : "2",
@@ -162,7 +163,8 @@
 			{ "a" : "4", "b" : "8", "guard" : 60000 }
 		]
 	},
-	"EXTREME II (ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design) xl+":
+	"EXTREME II xl+":
+	//(ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design)
 	{
 		"minSize" : "xl", "maxSize" : "xh",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/extreme.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/extreme.JSON
@@ -1,5 +1,6 @@
 {
-	"EXTREME (ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design)" :
+	"EXTREME" :
+	//(ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design)
 	{
 		"minSize" : "l", "maxSize" : "l",
 		"players" : "2",
@@ -190,7 +191,8 @@
 			{ "a" : "10", "b" : "11", "guard" : 100000 }
 		]
 	},
-	"EXTREME (ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design) xl+" :
+	"EXTREME xl+" :
+	//(ban fly/DD/orb inhibition/Castle-Necro-Conflux towns, 2 player, 3-Aug-03, midnight design)
 	{
 		"minSize" : "xl", "maxSize" : "xh",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/marathon.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/marathon.JSON
@@ -1,5 +1,6 @@
 {
-	"Marathon (ban fly/DD, 2 player, 31-May-03, midnight design)" :
+	"Marathon" :
+	// (ban fly/DD, 2 player, 31-May-03, midnight design)"
 	{
 		"minSize" : "xl", "maxSize" : "xl",
 		"players" : "2",
@@ -323,7 +324,8 @@
 			{ "a" : "23", "b" : "21", "guard" : 280000 }
 		]
 	},
-	"Marathon (ban fly/DD, 2 player, 31-May-03, midnight design) xlu+" :
+	"Marathon":
+	//(ban fly/DD, 2 player, 31-May-03, midnight design) xlu+"
 	{
 		"minSize" : "xl+u", "maxSize" : "g+u",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/panic.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/panic.JSON
@@ -1,5 +1,6 @@
 {
-	"Panic (ban fly/DD, 2 player, 3-Aug-03, midnight design)" :
+	"Panic" :
+	//(ban fly/DD, 2 player, 3-Aug-03, midnight design)
 	{
 		"minSize" : "m+u", "maxSize" : "l+u",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/poorjebus.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/poorjebus.JSON
@@ -1,5 +1,6 @@
 {
-	"Poor Jebus (made by Bjorn190, modified by Maretti and Angelito)" :
+	"Poor Jebus" :
+	//(made by Bjorn190, modified by Maretti and Angelito)
 	{
 		"minSize" : "m", "maxSize" : "xl+u",
 		"players" : "2-4",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/reckless.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/reckless.JSON
@@ -1,5 +1,6 @@
 {
-	"Reckless (2 player, 6-Jan-03, midnight design)" :
+	"Reckless" :
+	//(2 player, 6-Jan-03, midnight design)
 	{
 		"minSize" : "l", "maxSize" : "xl+u",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/roadrunner.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/roadrunner.JSON
@@ -1,5 +1,6 @@
 {
-	"Roadrunner (ban fly/DD, 2 player, 31-May-03, midnight design)" :
+	"Roadrunner" :
+	//(ban fly/DD, 2 player, 31-May-03, midnight design)
 	{
 		"minSize" : "xl", "maxSize" : "xl",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/skirmish.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/skirmish.JSON
@@ -1,5 +1,6 @@
 {
-	"Skirmish (ban fly/DD, 2 player, 3-Aug-03, midnight design)" :
+	"Skirmish" :
+	//(ban fly/DD, 2 player, 3-Aug-03, midnight design)
 	{
 		"minSize" : "m", "maxSize" : "m",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/superslam.JSON
+++ b/Mods/defaultTemplates/Mods/HDmod RMG Templates/Content/config/defaultTemplates/superslam.JSON
@@ -1,5 +1,6 @@
 {
-	"SuperSlam (2 player, Large or XL  no under)  For powermonger players, meet by SLAMMING thru super zones. Your chances are not over until the fat lady sings! Should ban spec log along with normal random rules." :
+	"SuperSlam" :
+	//(2 player, Large or XL  no under)  For powermonger players, meet by SLAMMING thru super zones. Your chances are not over until the fat lady sings! Should ban spec log along with normal random rules
 	{
 		"minSize" : "l", "maxSize" : "xl",
 		"players" : "2",

--- a/Mods/defaultTemplates/Mods/Multiplayer templates/Content/config/defaultTemplates/triad.JSON
+++ b/Mods/defaultTemplates/Mods/Multiplayer templates/Content/config/defaultTemplates/triad.JSON
@@ -1,5 +1,6 @@
 {
-	"Triad (ban fly/DD, 3 players, 9-Jan-03, midnight design)" :
+	"Triad" :
+	//(ban fly/DD, 3 players, 9-Jan-03, midnight design)
 	{
 		"minSize" : "l", "maxSize" : "l",
 		"players" : "2-3",

--- a/Mods/defaultTemplates/Mods/Multiplayer templates/Content/config/defaultTemplates/vortex.JSON
+++ b/Mods/defaultTemplates/Mods/Multiplayer templates/Content/config/defaultTemplates/vortex.JSON
@@ -1,5 +1,6 @@
 {
-	"Vortex (ban fly/DD, 3-4 player, 31-May-03, midnight design)" :
+	"Vortex" :
+	//(ban fly/DD, 3-4 player, 31-May-03, midnight design)
 	{
 		"minSize" : "xl", "maxSize" : "xl",
 		"players" : "2-4",


### PR DESCRIPTION
These actually cause visual glitches:
https://github.com/vcmi/vcmi/issues/1634

In the future, consider adding extra "description" field and show it somewhere in GUI and/or map description.