### PR TITLE
German translation

### DIFF
--- a/Mods/adventureMap/mod.json
+++ b/Mods/adventureMap/mod.json
@@ -17,5 +17,9 @@
 	"polish" : {
 		"name" : "Przyciski Ponownego Wejścia i Znajdź",
 		"description" : "Dodaje dwa nowe przyciski do interfejsu mapy przygód:<br><br>• <b>Wejdź ponownie</b> – umożliwia powrót do aktualnie zajmowanego obiektu<br>• <b>Znajdź</b> – pozwala znaleźć obiekt na już odkrytej części mapy<br><br>Zawiera także nową ikonę bohatera."
+	},
+	"german" : {
+		"name" : "Wiederbesuch- und Suchfunktion-Buttons",
+		"description" : "Erweiteret die Abenteuerkartenoberfläche mit zwei neuen Buttons:<br/><br/>• <b>Wiederbesuch</b> – erlaubt den erneuten Besuch des Objekts auf dem Euer Held gerade steht.<br/>• <b>Suchen</b> – erlaubt es Objekte im aufgedecken Bereich der Karte zu finden<br/><br/>Verbessert außerdem die Symbole für die Heldenoptionen.",
 	}
 }

--- a/Mods/arrowTowerIcons/mod.json
+++ b/Mods/arrowTowerIcons/mod.json
@@ -25,5 +25,9 @@
 	"polish" : {
 		"name" : "Ikony wież obronnych",
 		"description" : "Dodaje poprawne ikony wież obronnych na pasku inicjatywy podczas oblężeń zamku."
+	},
+	"german" : {
+		"name" : "Geschützturm-Icons",
+		"description" : "Verbessert die Icons für Geschütztürme während einer Stadtbelagerung."
 	}
 }

--- a/Mods/bonusIcons/mod.json
+++ b/Mods/bonusIcons/mod.json
@@ -17,5 +17,9 @@
 	"polish" : {
 		"name" : "Ikony bonusów",
 		"description" : "Zestaw ulepszeń graficznych dla statusu jednostek w walce:<br><br>• <b>Ikony bonusów i umiejętności</b> – dodaje ikony dla bonusów i umiejętności jednostek<br>• <b>Ikony odporności na czary</b> – pokazują odporność lub niewrażliwość na czary"
+	},
+	"german" : {
+		"name" : "Zusatzsymbole",
+		"description" : "Eine Sammlung grafischer Verbesserungen zum Einheitenstatus im Kampf:<br/><br/>• <b>Bonus- und Fähigkeits-Symbole</b> – fügt Symbole für Einheitenboni und -fähigkeiten hinzu<br/>• <b>Zauberimmunitäts-Symbole</b> – Zeigt Symbole für die Zauberimmunitäten oder -resistenzen von Kreaturen an"
 	}
 }

--- a/Mods/bonusIcons/mods/Bonus Icons/Content/translation/german.json
+++ b/Mods/bonusIcons/mods/Bonus Icons/Content/translation/german.json
@@ -1,0 +1,11 @@
+{
+	"creatures.core.ammoCart.bonus.inactive" : "{Inaktiv}\nNimmt nicht am Kampf teil. Die Effekte der Munitionskarre sind passiv.",
+	"creatures.core.ammoCart.bonus.siegeWeapon" : "{Munitionskarre}\nStellt unendlich Munition für Fernkampfeineiten bereit bis sie zerstört wird.",
+	"creatures.core.ballista.bonus.siegeWeapon" : "{Balliste}\nFernkampf-Kriegsmaschine, die Bolzen auf Feinde abfeuert.",
+	"creatures.core.catapult.bonus.siegeWeapon" : "{Katapult}\nKriegsmaschine zum Angreifen und Zerstören von Mauern, Toren und Geschütztürmen.",
+	"creatures.core.firstAidTent.bonus.heals" : "{Erste Hilfe-Zelt}\nHeilt Gesundheit der ersten Einheit eines verbündeten Trupps.",
+	"creatures.core.firstAidTent.bonus.siegeWeapon" : "{Erste Hilfe-Zelt}\nKriegsmaschine, die am Ende der Kampfrunde agiert.",
+	"creatures.core.halfling.bonus.lucky" : "{Positives Glück}\nDas Glück des Halblings kann nicht unter +1 reduziert werden.",
+	"creatures.core.minotaur.bonus.fearless" : "{Positive Moral}\nDie Moral des Minotauren kann nicht unter +1 reduziert werden.",
+	"creatures.core.minotaurKing.bonus.fearless" : "{Positive Moral}\nDie Moral des Minotaurenkönigs kann nicht unter +1 reduziert werden."
+}

--- a/Mods/bonusIcons/mods/Bonus Icons/mod.json
+++ b/Mods/bonusIcons/mods/Bonus Icons/mod.json
@@ -44,5 +44,12 @@
 	"polish" : {
 		"name" : "Ikony bonusów i umiejętności",
 		"description" : "Dodaje nowe graficzne ikony dla różnych bonusów i umiejętności jednostek. Poprawia czytelność podczas walki i na ekranie jednostek."
+	},
+	"german" : {
+		"name" : "Bonus- und Fähigkeitssymbole",
+		"description" : "Fügt neue Symbole für Boni und Fähigkeiten von Kreaturen hinzu um die Übersichtlichkeit im Kampf und dem Kreatureninformations-Fenster zu verbessern.",
+		"translations" : [
+			"translation/german.json"
+		]
 	}
 }

--- a/Mods/bonusIcons/mods/Immunity Icons/mod.json
+++ b/Mods/bonusIcons/mods/Immunity Icons/mod.json
@@ -22,5 +22,10 @@
 	"polish" : {
 		"name" : "Ikony odporności na czary",
 		"description" : "Dodaje ikony przedstawiające odporność lub niewrażliwość na czary jednostek, co poprawia przejrzystość podczas walki."
+	},
+	"german" : {
+		"name" : "Zauberimmunität-Symbole",
+		"description" : "Fügt Symbole für die Zauberimmunität und -resistenz von Kreaturen hinzu um die Übersichtlichkeit im Kampf zu verbessern."
 	}
+
 }

--- a/Mods/chroniclesIcon/mod.json
+++ b/Mods/chroniclesIcon/mod.json
@@ -27,5 +27,9 @@
 	"polish" : {
 		"name" : "Ikony Kronik",
 		"description" : "Ikony Kronik dla VCMI"
+	},
+	"german" : {
+		"name" : "Chronicles Icons",
+		"description" : "Chronicles Icons für VCMI.",
 	}
 }

--- a/Mods/emoji/mod.json
+++ b/Mods/emoji/mod.json
@@ -21,5 +21,9 @@
 	"polish" : {
 		"name" : "Obsługa emoji",
 		"description" : "Dodaje obsługę wyświetlania emoji w czacie gry dzięki czcionce wspierającej emoji."
+	},
+	"german" : {
+		"name" : "Emoji-Unterstützung",
+		"description" : "Erlaubt die Anzeige von Emojis im Ingame-Chat durch einen Emoji-kompatiblen Font."
 	}
 }

--- a/Mods/extendedLobby/mod.json
+++ b/Mods/extendedLobby/mod.json
@@ -75,7 +75,7 @@
 	},
 	"german" : {
 		"name" : "Erweiterte Lobby-Optionen",
-		"description" : "Verbessert die Spiel-Lobby mit erweiterter RMG-Konfiguration:<br><br>• Vorlagenauswahl<br>• Schach-Uhr<br>• Karten-Größen-Buttons für H / XH / C<br>• Unterstützung für simultane Züge",
+		"description" : "Verbessert die Spiel-Lobby mit erweiterter RMG-Konfiguration:<br/><br/>• Vorlagenauswahl<br/>• Schach-Uhr<br/>• Kartengrößen-Buttons für H / XH / C<br/>• Unterstützung für simultane Züge",
 		"translations" : {
 			"core.help.201.help" : "Eine extragroße Karte erstellen",
 			"vcmi.lobby.randomSize.HG.help" : "Eine riesige Karte erstellen",

--- a/Mods/quick-exchange/mod.json
+++ b/Mods/quick-exchange/mod.json
@@ -31,5 +31,9 @@
 	"polish" : {
 		"name" : "Szybka wymiana",
 		"description" : "Ten mod ulepsza okno wymiany bohaterów, dodając nowe przyciski ułatwiające przenoszenie.<br<br>>Dodaje:<br><br>• Przycisk wymiany wszystkich jednostek<br>• Przycisk wymiany wszystkich artefaktów<br>• Przyciski wymiany poszczególnych jednostek"
+	},
+	"german" : {
+		"name" : "Schnellaustausch",
+		"description" : "Diese Mod verbessert das Helden-Tauschfenster indem sie neue Buttons hinzufügt, die das Austauschen vereinfachen.<br/><br/>Fügt folgende Buttons hinzu:<br/><br/>• Tausche alle Truppen<br/>• Tausche alle Artefakte<br/>• Buttons zum Austasch einzelner Kreaturentrupps.",
 	}
 }

--- a/content/translation/german.json
+++ b/content/translation/german.json
@@ -1,0 +1,19 @@
+{
+	"creatures.core.airElemental.bonus.dummyVulnerablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Armageddon, Blitzstrahl und -Salve und Titanen-Blitzstrahl.",
+	"creatures.core.ammoCart.bonus.dummyIcon" : "{Munitionskarre}\nStellt unendlich Munition für Fernkampfeineiten bereit bis sie zerstört wird.",
+	"creatures.core.crystalDragon.bonus.dummycrystalIcon" : "{Kristall-Erzeugung}\nGeneriert zusätzliche +3 Kristalle bei Beginn einer neuen Woche.",
+	"creatures.core.earthElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Meteorregen.",
+	"creatures.core.enchanter.bonus.dummyabilityIcon" : "{Verzauberer}\nKann verschiedene Zauber zum Zugbeginn aussprechen.",
+	"creatures.core.energyElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Eisstrahl und Frostring.",
+	"creatures.core.fireElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Eisstrahl und Frostring.",
+	"creatures.core.halfling.bonus.dummyluckyicon" : "{Positives Glück}\nDas Glück des Halblings kann nicht unter +1 reduziert werden.",
+	"creatures.core.iceElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Armageddon, Fireball, und Inferno.",
+	"creatures.core.magmaElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Meteorregen.",
+	"creatures.core.minotaur.bonus.dummyMoraleIcon" : "{Positive Moral}\nDie Moral des Minotauren kann nicht unter +1 reduziert werden.",
+	"creatures.core.minotaurKing.bonus.dummyMoraleIcon" : "{Positive Moral}\nDie Moral des Minotaurenkönigs kann nicht unter +1 reduziert werden.",
+	"creatures.core.stormElemental.bonus.dummyVulnerablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Armageddon, Blitzstrahl und -Salve und Titanen-Blitzstrahl.",
+	"creatures.core.waterElemental.bonus.dummyVulnerablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Armageddon, Feuerball und Inferno.",
+	"vcmi.lobby.randomSize.C.help" : "Eine Karte, mit benutzerdefinierter Größe erstellen",
+	"vcmi.lobby.randomSize.HG.help" : "Eine riesige Karte erstellen",
+	"vcmi.lobby.randomSize.XH.help" : "Eine extrariesige Karte erstellen"
+}

--- a/content/translation/german.json
+++ b/content/translation/german.json
@@ -1,7 +1,7 @@
 {
 	"creatures.core.airElemental.bonus.dummyVulnerablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Armageddon, Blitzstrahl und -Salve und Titanen-Blitzstrahl.",
 	"creatures.core.ammoCart.bonus.dummyIcon" : "{Munitionskarre}\nStellt unendlich Munition für Fernkampfeineiten bereit bis sie zerstört wird.",
-	"creatures.core.crystalDragon.bonus.dummycrystalIcon" : "{Kristall-Erzeugung}\nGeneriert zusätzliche +3 Kristalle bei Beginn einer neuen Woche.",
+	"creatures.core.crystalDragon.bonus.dummycrystalIcon" : "{Kristall-Erzeugung}\nGeneriert zusätzliche +3 Kristalle zu Beginn einer neuen Woche.",
 	"creatures.core.earthElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Meteorregen.",
 	"creatures.core.enchanter.bonus.dummyabilityIcon" : "{Verzauberer}\nKann verschiedene Zauber zum Zugbeginn aussprechen.",
 	"creatures.core.energyElemental.bonus.dummyVulneablityIcon" : "{Zauberanfälligkeit}\nDoppelter Schaden durch Eisstrahl und Frostring.",

--- a/mod.json
+++ b/mod.json
@@ -220,5 +220,12 @@
 		"translations" : [
 			"translation/turkish.json"
 		]
+	},
+	"german" : {
+		"name" : "VCMI Extras",
+		"description" : "Eine Sammlung von Korrekturen und Verbesserungen der VCMI Spieloberfläche und Gameplay:<br/><br/>• <b>Erweiterte Lobby-Optionen</b><br/> Fügt Vorlagenauswahl, Kartengrößen-Buttons &#40;H/XH/C&#41;, Schach-Uhr und Unterstützung für simultane Züge hinzu<br/><br/>• <b>Wiederbesuch- und Suchfunktion-Buttons</b><br/> Erweiteret die Abenteuerkarten-Oberfläche mit Buttons zum Wiederbesuch des derzeit besuchten Objekts und einer Suchfunktion<br/><br/>• <b>Schnellaustausch</b><br/> Erweitert das Helden-Austausch-Fenster um Buttons um das Tauschen der gesamten Armee oder Artefakte mit einem Klick zu ermöglichen<br/><br/>• <b>Vertikales Layout &#40;Portrait-Modus&#41;</b><br/> Optimiert die Abenteuerkarten-Oberfläche wenn das vertikale Layout &#40;Portrait-Modus&#41; benutzt wird<br/><br/>• <b>Zusatzsymbole</b><br/> Fügt weitere Symbole für die Fähigkeiten der Kreaturen hinzu:<br/><br/>• <b>Zauberimmunität</b><br/> Zeigt während des Kampfes Symbole für die Zauberimmunitäten verschiedener Kreaturen an<br/><br/>• <b>Emoji-Unterstützung</b><br/> Erlaubt die Anzeige von Emojis im Ingame-Chat.",
+		"translations" : [
+			"translation/german.json"
+		]
 	}
 }


### PR DESCRIPTION
Adds a complete German translation to vcmi-extras and its submods.

As a sidenote: Why does the mod add superfluous icons (e.g. ammo cart icon is added twice). It should also hide irrelevant bonuses like the individual spell vulnerabilities of the elementals since it adds a description for all of them in one dummy-bonus.